### PR TITLE
Introduced isNothing

### DIFF
--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -1,7 +1,7 @@
-module Maybe.Extra where
+module Maybe.Extra ((?), join, isNothing) where
 {-| Convenience functions for Maybe.
 
-@docs (?), join
+@docs (?), join, isNothing
 -}
 
 import Maybe (..)
@@ -26,3 +26,17 @@ join mx =
   case mx of
     Just x -> x
     Nothing -> Nothing
+
+
+{-| Conveniently check if constructed with `Nothing`.
+
+      isNothing (Just 42) == False
+      isNothing (Just []) == False
+      isNothing Nothing   == True
+-}
+isNothing : Maybe a -> Bool
+isNothing m =
+    case m of
+      Nothing -> True
+      Just _  -> False
+


### PR DESCRIPTION
... with the documentation it once had in the standard lib.

I have argued elsewhere (https://github.com/elm-lang/core/pull/164) that `Maybe.isNothing` should be re-introduced into the standard lib. In the meantime, maybe it is not too bad to have it here.