### PR TITLE
Many new functions, including maybe, unsafe, ap, traverse, sequence

### DIFF
--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -1,14 +1,11 @@
 module Maybe.Extra
-  ( (?)
-  , join
-  , isNothing
-  , isJust
+  ( (?), join, isNothing, isJust
   , map2, map3, map4, map5
-  , andMap, next, prev
-  , or
-  , listToMaybe, maybeToList, arrayToMaybe, maybeToArray
+  , andMap, next, prev, or
+  , maybeToList, maybeToArray
   , traverse, combine, traverseArray, combineArray
   ) where
+
 {-| Convenience functions for Maybe.
 
 # Common helpers
@@ -21,7 +18,7 @@ module Maybe.Extra
 @docs andMap, next, prev, or
 
 # List and array functions
-@docs listToMaybe, maybeToList, arrayToMaybe, maybeToArray, traverse, combine, traverseArray, combineArray
+@docs maybeToList, maybeToArray, traverse, combine, traverseArray, combineArray
 -}
 
 import Array
@@ -147,18 +144,6 @@ or ma mb =
     Just _ -> ma
 
 
-{-| Returns `Nothing` on an empty list or `Just a`, where `a` is the first element of the list.
-
-    listToMaybe [] == Nothing
-    listToMaybe [1,2,3] == Just 1
--}
-listToMaybe : List a -> Maybe a
-listToMaybe xs =
-  case xs of
-    [] -> Nothing
-    (x::_) -> Just x
-
-
 {-| Return an empty list on `Nothing` or a list with one element, where the element is the value of `Just`.
 
     maybeToList Nothing == []
@@ -169,16 +154,6 @@ maybeToList m =
   case m of
     Nothing -> []
     Just x -> [x]
-
-
-{-| Returns `Nothing` on an empty array or `Just a`, where `a` is the first element of the array.
-
-    arrayToMaybe (Array.fromList []) == Nothing
-    arrayToMaybe (Array.fromList [1,2,3]) == Just 1
-
--}
-arrayToMaybe : Array.Array a -> Maybe a
-arrayToMaybe = Array.get 0
 
 
 {-| Return an empty array on `Nothing` or a list with one element, where the element is the value of `Just`.

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -3,33 +3,28 @@ module Maybe.Extra
   , join
   , isNothing
   , isJust
-  , keepJusts
-  , maybe
-  , unsafe
   , map2, map3, map4, map5
-  , mapReplaceBy
-  , ap, next, prev
+  , andMap, next, prev
   , or
   , listToMaybe, maybeToList, arrayToMaybe, maybeToArray
-  , traverse, sequence, traverseArray, sequenceArray
+  , traverse, combine, traverseArray, combineArray
   ) where
 {-| Convenience functions for Maybe.
 
 # Common helpers
-@docs (?), join, isNothing, isJust, keepJusts, maybe, unsafe
+@docs (?), join, isNothing, isJust
 
 # Map
 @docs map2, map3, map4, map5
 
 # Applicative functions
-@docs mapReplaceBy, ap, next, prev, or
+@docs andMap, next, prev, or
 
 # List and array functions
-@docs listToMaybe, maybeToList, arrayToMaybe, maybeToArray, traverse, sequence, traverseArray, sequenceArray
+@docs listToMaybe, maybeToList, arrayToMaybe, maybeToArray, traverse, combine, traverseArray, combineArray
 -}
 
 import Array
-import Debug
 import Maybe exposing (..)
 
 {-| Flipped, infix version of `withDefault`.
@@ -75,38 +70,6 @@ isJust m =
     Nothing -> False
     Just _  -> True
 
-{-| Take a list of `Maybe`s and return the list of all values inside `Just`s.
-
-    keepJusts [Nothing, Just 1, Nothing, Just 2, Just 3] == [1,2,3]
--}
-keepJusts : List (Maybe a) -> List a
-keepJusts =
-  let
-    step e acc =
-      case e of
-        Nothing -> acc
-        Just x -> x::acc
-  in
-    List.foldr step []
-
-
-{-| Take default value, a function, and a `Maybe` value. If the `Maybe` value is `Nothing`, the function returns the default value. Otherwise, it applies the function to the value of `Just` and returns the result.
-
-    maybe [] ((::)0) Nothing == []
-    maybe [] ((::)0) (Just [1,2,3]) == [0,1,2,3]
--}
-maybe : b -> (a -> b) -> Maybe a -> b
-maybe d f = withDefault d << map f
-
-
-{-| Extracts the value, if it's `Just`, or throw an error, if it's `Nothing`.
--}
-unsafe : Maybe a -> a
-unsafe v =
-  case v of
-    Nothing -> Debug.crash "Can't extract value from Nothing!"
-    Just x -> x
-
 
 {-| Combine two `Maybe`s with the given function. If one of the `Maybe`s is `Nothing`, the result is `Nothing`.
 
@@ -114,39 +77,31 @@ unsafe v =
     map2 (,) (Just 0) (Just 'a') == Just (0, 'a')
 -}
 map2 : (a -> b -> c) -> Maybe a -> Maybe b -> Maybe c
-map2 f a b = map f a `ap` b
+map2 f a b = map f a `andMap` b
 
 {-|-}
 map3 : (a -> b -> c -> d) -> Maybe a -> Maybe b -> Maybe c -> Maybe d
-map3 f a b c = map f a `ap` b `ap` c
+map3 f a b c = map f a `andMap` b `andMap` c
 
 {-|-}
 map4 : (a -> b -> c -> d -> e) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe e
-map4 f a b c d = map f a `ap` b `ap` c `ap` d
+map4 f a b c d = map f a `andMap` b `andMap` c `andMap` d
 
 {-|-}
 map5 : (a -> b -> c -> d -> e -> f) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe e -> Maybe f
-map5 f a b c d e = map f a `ap` b `ap` c `ap` d `ap` e
-
-
-{-| Replace the value inside `Just` with a new value (possibly of a different type). Otherwise, return `Nothing`.
-
-Advanced functional programmers will recognize this as the implementation of `<$` for `Maybe`s from the `Functor` typeclass, where `<$ == map << always`.
--}
-mapReplaceBy : a -> Maybe b -> Maybe a
-mapReplaceBy = map << always
+map5 f a b c d e = map f a `andMap` b `andMap` c `andMap` d `andMap` e
 
 
 {-| Apply the function that is inside `Maybe` to a value that is inside `Maybe`. Return the result inside `Maybe`. If one of the `Maybe` arguments is `Nothing`, return `Nothing`.
 
-    Just ((+)2) `ap` Just 3 == Just 5
-    Just Nothing `ap` Just 3 == Nothing
-    Just ((+)2) `ap` Nothing == Nothing
+    Just ((+)2) `andMap` Just 3 == Just 5
+    Just Nothing `andMap` Just 3 == Nothing
+    Just ((+)2) `andMap` Nothing == Nothing
 
 Advanced functional programmers will recognize this as the implementation of `<*>` for `Maybe`s from the `Applicative` typeclass.
 -}
-ap : Maybe (a -> b) -> Maybe a -> Maybe b
-ap f x = x `andThen` (\x' -> f `andThen` (\f' -> Just <| f' x'))
+andMap : Maybe (a -> b) -> Maybe a -> Maybe b
+andMap f x = x `andThen` (\x' -> f `andThen` (\f' -> Just <| f' x'))
 
 
 {-| Take two `Maybe` values. If the first one equals `Nothing`, return `Nothing`. Otherwise return the second value.
@@ -254,14 +209,14 @@ traverse f =
     List.foldr step (Just [])
 
 
-{-| Take a list of `Maybe`s and return a `Maybe` with a list of values. `sequence == traverse identity`.
+{-| Take a list of `Maybe`s and return a `Maybe` with a list of values. `combine == traverse identity`.
 
-    sequence [] == Just []
-    sequence [Just 1, Just 2, Just 3] == Just [1,2,3]
-    sequence [Just 1, Nothing, Just 3] == Nothing
+    combine [] == Just []
+    combine [Just 1, Just 2, Just 3] == Just [1,2,3]
+    combine [Just 1, Nothing, Just 3] == Nothing
 -}
-sequence : List (Maybe a) -> Maybe (List a)
-sequence = traverse identity
+combine : List (Maybe a) -> Maybe (List a)
+combine = traverse identity
 
 
 {-|-}
@@ -277,5 +232,5 @@ traverseArray f =
 
 
 {-|-}
-sequenceArray : Array.Array (Maybe a) -> Maybe (Array.Array a)
-sequenceArray = traverseArray identity
+combineArray : Array.Array (Maybe a) -> Maybe (Array.Array a)
+combineArray = traverseArray identity

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -3,13 +3,33 @@ module Maybe.Extra
   , join
   , isNothing
   , isJust
+  , keepJusts
+  , maybe
+  , unsafe
+  , map2, map3, map4, map5
+  , mapReplaceBy
+  , ap, next, prev
   , or
+  , listToMaybe, maybeToList, arrayToMaybe, maybeToArray
+  , traverse, sequence, traverseArray, sequenceArray
   ) where
 {-| Convenience functions for Maybe.
 
-@docs (?), join, isNothing, isJust, or
+# Common helpers
+@docs (?), join, isNothing, isJust, keepJusts, maybe, unsafe
+
+# Map
+@docs map2, map3, map4, map5
+
+# Applicative functions
+@docs mapReplaceBy, ap, next, prev, or
+
+# List and array functions
+@docs listToMaybe, maybeToList, arrayToMaybe, maybeToArray, traverse, sequence, traverseArray, sequenceArray
 -}
 
+import Array
+import Debug
 import Maybe exposing (..)
 
 {-| Flipped, infix version of `withDefault`.
@@ -55,6 +75,103 @@ isJust m =
     Nothing -> False
     Just _  -> True
 
+{-| Take a list of `Maybe`s and return the list of all values inside `Just`s.
+
+    keepJusts [Nothing, Just 1, Nothing, Just 2, Just 3] == [1,2,3]
+-}
+keepJusts : List (Maybe a) -> List a
+keepJusts =
+  let
+    step e acc =
+      case e of
+        Nothing -> acc
+        Just x -> x::acc
+  in
+    List.foldr step []
+
+
+{-| Take default value, a function, and a `Maybe` value. If the `Maybe` value is `Nothing`, the function returns the default value. Otherwise, it applies the function to the value of `Just` and returns the result.
+
+    maybe [] ((::)0) Nothing == []
+    maybe [] ((::)0) (Just [1,2,3]) == [0,1,2,3]
+-}
+maybe : b -> (a -> b) -> Maybe a -> b
+maybe d f = withDefault d << map f
+
+
+{-| Extracts the value, if it's `Just`, or throw an error, if it's `Nothing`.
+-}
+unsafe : Maybe a -> a
+unsafe v =
+  case v of
+    Nothing -> Debug.crash "Can't extract value from Nothing!"
+    Just x -> x
+
+
+{-| Combine two `Maybe`s with the given function. If one of the `Maybe`s is `Nothing`, the result is `Nothing`.
+
+    map2 (+) (Just 1) (Just 2) == Just 3
+    map2 (,) (Just 0) (Just 'a') == Just (0, 'a')
+-}
+map2 : (a -> b -> c) -> Maybe a -> Maybe b -> Maybe c
+map2 f a b = map f a `ap` b
+
+{-|-}
+map3 : (a -> b -> c -> d) -> Maybe a -> Maybe b -> Maybe c -> Maybe d
+map3 f a b c = map f a `ap` b `ap` c
+
+{-|-}
+map4 : (a -> b -> c -> d -> e) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe e
+map4 f a b c d = map f a `ap` b `ap` c `ap` d
+
+{-|-}
+map5 : (a -> b -> c -> d -> e -> f) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe e -> Maybe f
+map5 f a b c d e = map f a `ap` b `ap` c `ap` d `ap` e
+
+
+{-| Replace the value inside `Just` with a new value (possibly of a different type). Otherwise, return `Nothing`.
+
+Advanced functional programmers will recognize this as the implementation of `<$` for `Maybe`s from the `Functor` typeclass, where `<$ == map << always`.
+-}
+mapReplaceBy : a -> Maybe b -> Maybe a
+mapReplaceBy = map << always
+
+
+{-| Apply the function that is inside `Maybe` to a value that is inside `Maybe`. Return the result inside `Maybe`. If one of the `Maybe` arguments is `Nothing`, return `Nothing`.
+
+    Just ((+)2) `ap` Just 3 == Just 5
+    Just Nothing `ap` Just 3 == Nothing
+    Just ((+)2) `ap` Nothing == Nothing
+
+Advanced functional programmers will recognize this as the implementation of `<*>` for `Maybe`s from the `Applicative` typeclass.
+-}
+ap : Maybe (a -> b) -> Maybe a -> Maybe b
+ap f x = x `andThen` (\x' -> f `andThen` (\f' -> Just <| f' x'))
+
+
+{-| Take two `Maybe` values. If the first one equals `Nothing`, return `Nothing`. Otherwise return the second value.
+
+    next (Just 1) (Just 2) == Just 2
+    next Nothing (Just 2) == Nothing
+    next (Just 1) Nothing == Nothing
+
+Advanced functional programmers will recognize this as the implementation of `*>` for `Maybe`s from the `Applicative` typeclass.
+-}
+next : Maybe a -> Maybe b -> Maybe b
+next = map2 (flip always)
+
+
+{-| Take two `Maybe` values. If the second one equals `Nothing`, return `Nothing`. Otherwise return the first value.
+
+    prev (Just 1) (Just 2) == Just 1
+    prev Nothing (Just 2) == Nothing
+    prev (Just 1) Nothing == Nothing
+
+Advanced functional programmers will recognize this as the implementation of `<*` for `Maybe`s from the `Applicative` typeclass.
+-}
+prev : Maybe a -> Maybe b -> Maybe a
+prev = map2 always
+
 
 {-|
   Like the boolean '||' this will return the first value that is positive ('Just').
@@ -73,3 +190,92 @@ or ma mb =
   case ma of
     Nothing -> mb
     Just _ -> ma
+
+
+{-| Returns `Nothing` on an empty list or `Just a`, where `a` is the first element of the list.
+
+    listToMaybe [] == Nothing
+    listToMaybe [1,2,3] == Just 1
+-}
+listToMaybe : List a -> Maybe a
+listToMaybe xs =
+  case xs of
+    [] -> Nothing
+    (x::_) -> Just x
+
+
+{-| Return an empty list on `Nothing` or a list with one element, where the element is the value of `Just`.
+
+    maybeToList Nothing == []
+    maybeToList (Just 1) == [1]
+-}
+maybeToList : Maybe a -> List a
+maybeToList m =
+  case m of
+    Nothing -> []
+    Just x -> [x]
+
+
+{-| Returns `Nothing` on an empty array or `Just a`, where `a` is the first element of the array.
+
+    arrayToMaybe (Array.fromList []) == Nothing
+    arrayToMaybe (Array.fromList [1,2,3]) == Just 1
+
+-}
+arrayToMaybe : Array.Array a -> Maybe a
+arrayToMaybe = Array.get 0
+
+
+{-| Return an empty array on `Nothing` or a list with one element, where the element is the value of `Just`.
+
+    maybeToArray Nothing == Array.fromList []
+    maybeToArray (Just 1) == Array.fromList [1]
+
+-}
+maybeToArray : Maybe a -> Array.Array a
+maybeToArray m =
+  case m of
+    Nothing -> Array.empty
+    Just x -> Array.repeat 1 x
+
+
+{-| Take a function that returns `Maybe` value and a list. Map a function over each element of the list. Collect the result in the list within `Maybe`.
+
+    traverse (\x -> Just (x*10)) [1,2,3,4,5] == Just [10,20,30,40,50]
+-}
+traverse : (a -> Maybe b) -> List a -> Maybe (List b)
+traverse f =
+  let
+    step e acc =
+      case f e of
+        Nothing -> Nothing
+        Just x -> map ((::)x) acc
+  in
+    List.foldr step (Just [])
+
+
+{-| Take a list of `Maybe`s and return a `Maybe` with a list of values. `sequence == traverse identity`.
+
+    sequence [] == Just []
+    sequence [Just 1, Just 2, Just 3] == Just [1,2,3]
+    sequence [Just 1, Nothing, Just 3] == Nothing
+-}
+sequence : List (Maybe a) -> Maybe (List a)
+sequence = traverse identity
+
+
+{-|-}
+traverseArray : (a -> Maybe b) -> Array.Array a -> Maybe (Array.Array b)
+traverseArray f =
+  let
+    step e acc =
+      case f e of
+        Nothing -> Nothing
+        Just x -> map (Array.push x) acc
+  in
+    Array.foldl step (Just Array.empty)
+
+
+{-|-}
+sequenceArray : Array.Array (Maybe a) -> Maybe (Array.Array a)
+sequenceArray = traverseArray identity


### PR DESCRIPTION
I wrote new functions that work with Maybe. You might argue that some of them won't be used often at all, such as `next`, `prev`, `listToMaybe`, `maybeToList`, `mapReplaceBy`. I am however absolutely sure that `keepJusts`, `unsafe`, `maybe`, `map2`, `ap`, `traverse` and `sequence` will be used.

- @TheSeamau5 used `keepJusts` [in his Zipper implementation](https://gist.github.com/TheSeamau5/dee7da3b1646f24cf06f).
- @evancz proposed to add `unsafe` in [this issue](https://github.com/elm-lang/core/issues/215)
- I use `maybe` in some functions for lists
- I use `sequence` in my implementation of `type alias Matrix a = Array (Array a)`:

    getCol : Int -> Matrix a -> Maybe (Array a) -- returns a column from a matrix
    getCol n a = Maybe.sequenceArray <| Array.map (Array.get n) a

I'm happy to change documentation and function names to whatever you find appropriate. In [this issue about ? operator](https://github.com/elm-lang/core/issues/216) @evancz was concerned that adding too many infix operators is bad (see also [style guide](http://elm-lang.org/docs/style-guide)). 

That's why I didn't add operators like `<*>`, `<*`, `<$`, `*>`. However I chose `ap` instead of `apply` because this function might be used infix style, therefore it should be short. I was unsure how to name `<$`, `<*` and `*>`, so I went with gut + [StackOverflow question on operator pronunciation](http://stackoverflow.com/q/7746894/596361).

Please feel free to change function names, documentation, code style and such to whatever you want.