### PR TITLE
Updates to work with 0.18 and added new function `values`

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -10,7 +10,7 @@
         "Maybe.Extra"
     ],
     "dependencies": {
-        "elm-lang/core": "2.0.0 <= v < 4.0.0"
+        "elm-lang/core": "2.0.0 <= v < 6.0.0"
     },
-    "elm-version": "0.15.0 <= v < 0.17.0"
+    "elm-version": "0.15.0 <= v < 0.19.0"
 }

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -83,7 +83,7 @@ mapDefault d f m =
 Advanced functional programmers will recognize this as the implementation of `<*>` for `Maybe`s from the `Applicative` typeclass.
 -}
 andMap : Maybe (a -> b) -> Maybe a -> Maybe b
-andMap f x = x `andThen` (\x' -> f `andThen` (\f' -> Just <| f' x'))
+andMap f x = x |> andThen (\x_ -> f |> andThen (\f_ -> Just <| f_ x_))
 
 
 {-| Take two `Maybe` values. If the first one equals `Nothing`, return `Nothing`. Otherwise return the second value.

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -15,6 +15,7 @@ module Maybe.Extra
         , combine
         , traverseArray
         , combineArray
+        , values
         )
 
 {-| Convenience functions for Maybe.
@@ -26,7 +27,7 @@ module Maybe.Extra
 @docs andMap, next, prev, or
 
 # List and array functions
-@docs maybeToList, maybeToArray, traverse, combine, traverseArray, combineArray
+@docs maybeToList, maybeToArray, traverse, combine, traverseArray, combineArray, values
 -}
 
 import Array
@@ -245,3 +246,23 @@ traverseArray f =
 combineArray : Array.Array (Maybe a) -> Maybe (Array.Array a)
 combineArray =
     traverseArray identity
+
+
+{-| Convet a list of `Maybe a` to a list of `a` only for the values different
+from `Nothing`.
+
+    values [ Just 1, Nothing, Just 2 ] == [1, 2]
+-}
+values : List (Maybe a) -> List a
+values =
+    List.foldr foldrValues []
+
+
+foldrValues : Maybe a -> List a -> List a
+foldrValues item list =
+    case item of
+        Nothing ->
+            list
+
+        Just v ->
+            v :: list

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -1,9 +1,21 @@
-module Maybe.Extra exposing
-  ( (?), join, isNothing, isJust
-  , mapDefault, andMap, next, prev, or
-  , maybeToList, maybeToArray
-  , traverse, combine, traverseArray, combineArray
-  )
+module Maybe.Extra
+    exposing
+        ( (?)
+        , join
+        , isNothing
+        , isJust
+        , mapDefault
+        , andMap
+        , next
+        , prev
+        , or
+        , maybeToList
+        , maybeToArray
+        , traverse
+        , combine
+        , traverseArray
+        , combineArray
+        )
 
 {-| Convenience functions for Maybe.
 
@@ -20,12 +32,15 @@ module Maybe.Extra exposing
 import Array
 import Maybe exposing (..)
 
+
 {-| Flipped, infix version of `withDefault`.
 
     head [] ? 0 == 0
 -}
 (?) : Maybe a -> a -> a
-(?) mx x = withDefault x mx
+(?) mx x =
+    withDefault x mx
+
 
 {-| Flattens nested Maybes
 
@@ -35,9 +50,13 @@ import Maybe exposing (..)
 -}
 join : Maybe (Maybe a) -> Maybe a
 join mx =
-  case mx of
-    Just x -> x
-    Nothing -> Nothing
+    case mx of
+        Just x ->
+            x
+
+        Nothing ->
+            Nothing
+
 
 {-| Conveniently check if a `Maybe` matches `Nothing`.
 
@@ -47,9 +66,13 @@ join mx =
 -}
 isNothing : Maybe a -> Bool
 isNothing m =
-  case m of
-    Nothing -> True
-    Just _  -> False
+    case m of
+        Nothing ->
+            True
+
+        Just _ ->
+            False
+
 
 {-| Conveniently check if a `Maybe` matches `Just _`.
 
@@ -59,9 +82,13 @@ isNothing m =
 -}
 isJust : Maybe a -> Bool
 isJust m =
-  case m of
-    Nothing -> False
-    Just _  -> True
+    case m of
+        Nothing ->
+            False
+
+        Just _ ->
+            True
+
 
 {-| Take a default value, a function and a `Maybe`.
 Return the default value if the `Maybe` is `Nothing`.
@@ -70,9 +97,13 @@ That is, `mapDefault d f` is equivalent to `Maybe.map f >> Maybe.withDefault d`.
 -}
 mapDefault : b -> (a -> b) -> Maybe a -> b
 mapDefault d f m =
-  case m of
-    Nothing -> d
-    Just a  -> f a
+    case m of
+        Nothing ->
+            d
+
+        Just a ->
+            f a
+
 
 {-| Apply the function that is inside `Maybe` to a value that is inside `Maybe`. Return the result inside `Maybe`. If one of the `Maybe` arguments is `Nothing`, return `Nothing`.
 
@@ -83,7 +114,8 @@ mapDefault d f m =
 Advanced functional programmers will recognize this as the implementation of `<*>` for `Maybe`s from the `Applicative` typeclass.
 -}
 andMap : Maybe (a -> b) -> Maybe a -> Maybe b
-andMap f x = x |> andThen (\x_ -> f |> andThen (\f_ -> Just <| f_ x_))
+andMap f x =
+    x |> andThen (\x_ -> f |> andThen (\f_ -> Just <| f_ x_))
 
 
 {-| Take two `Maybe` values. If the first one equals `Nothing`, return `Nothing`. Otherwise return the second value.
@@ -95,7 +127,8 @@ andMap f x = x |> andThen (\x_ -> f |> andThen (\f_ -> Just <| f_ x_))
 Advanced functional programmers will recognize this as the implementation of `*>` for `Maybe`s from the `Applicative` typeclass.
 -}
 next : Maybe a -> Maybe b -> Maybe b
-next = map2 (flip always)
+next =
+    map2 (flip always)
 
 
 {-| Take two `Maybe` values. If the second one equals `Nothing`, return `Nothing`. Otherwise return the first value.
@@ -107,7 +140,8 @@ next = map2 (flip always)
 Advanced functional programmers will recognize this as the implementation of `<*` for `Maybe`s from the `Applicative` typeclass.
 -}
 prev : Maybe a -> Maybe b -> Maybe a
-prev = map2 always
+prev =
+    map2 always
 
 
 {-|
@@ -124,9 +158,12 @@ prev = map2 always
 -}
 or : Maybe a -> Maybe a -> Maybe a
 or ma mb =
-  case ma of
-    Nothing -> mb
-    Just _ -> ma
+    case ma of
+        Nothing ->
+            mb
+
+        Just _ ->
+            ma
 
 
 {-| Return an empty list on `Nothing` or a list with one element, where the element is the value of `Just`.
@@ -136,9 +173,12 @@ or ma mb =
 -}
 maybeToList : Maybe a -> List a
 maybeToList m =
-  case m of
-    Nothing -> []
-    Just x -> [x]
+    case m of
+        Nothing ->
+            []
+
+        Just x ->
+            [ x ]
 
 
 {-| Return an empty array on `Nothing` or a list with one element, where the element is the value of `Just`.
@@ -149,9 +189,12 @@ maybeToList m =
 -}
 maybeToArray : Maybe a -> Array.Array a
 maybeToArray m =
-  case m of
-    Nothing -> Array.empty
-    Just x -> Array.repeat 1 x
+    case m of
+        Nothing ->
+            Array.empty
+
+        Just x ->
+            Array.repeat 1 x
 
 
 {-| Take a function that returns `Maybe` value and a list. Map a function over each element of the list. Collect the result in the list within `Maybe`.
@@ -160,13 +203,16 @@ maybeToArray m =
 -}
 traverse : (a -> Maybe b) -> List a -> Maybe (List b)
 traverse f =
-  let
-    step e acc =
-      case f e of
-        Nothing -> Nothing
-        Just x -> map ((::)x) acc
-  in
-    List.foldr step (Just [])
+    let
+        step e acc =
+            case f e of
+                Nothing ->
+                    Nothing
+
+                Just x ->
+                    map ((::) x) acc
+    in
+        List.foldr step (Just [])
 
 
 {-| Take a list of `Maybe`s and return a `Maybe` with a list of values. `combine == traverse identity`.
@@ -176,21 +222,26 @@ traverse f =
     combine [Just 1, Nothing, Just 3] == Nothing
 -}
 combine : List (Maybe a) -> Maybe (List a)
-combine = traverse identity
+combine =
+    traverse identity
 
 
-{-|-}
+{-| -}
 traverseArray : (a -> Maybe b) -> Array.Array a -> Maybe (Array.Array b)
 traverseArray f =
-  let
-    step e acc =
-      case f e of
-        Nothing -> Nothing
-        Just x -> map (Array.push x) acc
-  in
-    Array.foldl step (Just Array.empty)
+    let
+        step e acc =
+            case f e of
+                Nothing ->
+                    Nothing
+
+                Just x ->
+                    map (Array.push x) acc
+    in
+        Array.foldl step (Just Array.empty)
 
 
-{-|-}
+{-| -}
 combineArray : Array.Array (Maybe a) -> Maybe (Array.Array a)
-combineArray = traverseArray identity
+combineArray =
+    traverseArray identity

--- a/src/Maybe/Extra.elm
+++ b/src/Maybe/Extra.elm
@@ -1,18 +1,14 @@
-module Maybe.Extra
+module Maybe.Extra exposing
   ( (?), join, isNothing, isJust
-  , map2, map3, map4, map5, mapDefault
-  , andMap, next, prev, or
+  , mapDefault, andMap, next, prev, or
   , maybeToList, maybeToArray
   , traverse, combine, traverseArray, combineArray
-  ) where
+  )
 
 {-| Convenience functions for Maybe.
 
 # Common helpers
 @docs (?), join, isNothing, isJust, mapDefault
-
-# Map
-@docs map2, map3, map4, map5
 
 # Applicative functions
 @docs andMap, next, prev, or
@@ -77,27 +73,6 @@ mapDefault d f m =
   case m of
     Nothing -> d
     Just a  -> f a
-  
-{-| Combine two `Maybe`s with the given function. If one of the `Maybe`s is `Nothing`, the result is `Nothing`.
-
-    map2 (+) (Just 1) (Just 2) == Just 3
-    map2 (,) (Just 0) (Just 'a') == Just (0, 'a')
--}
-map2 : (a -> b -> c) -> Maybe a -> Maybe b -> Maybe c
-map2 f a b = map f a `andMap` b
-
-{-|-}
-map3 : (a -> b -> c -> d) -> Maybe a -> Maybe b -> Maybe c -> Maybe d
-map3 f a b c = map f a `andMap` b `andMap` c
-
-{-|-}
-map4 : (a -> b -> c -> d -> e) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe e
-map4 f a b c d = map f a `andMap` b `andMap` c `andMap` d
-
-{-|-}
-map5 : (a -> b -> c -> d -> e -> f) -> Maybe a -> Maybe b -> Maybe c -> Maybe d -> Maybe e -> Maybe f
-map5 f a b c d e = map f a `andMap` b `andMap` c `andMap` d `andMap` e
-
 
 {-| Apply the function that is inside `Maybe` to a value that is inside `Maybe`. Return the result inside `Maybe`. If one of the `Maybe` arguments is `Nothing`, return `Nothing`.
 


### PR DESCRIPTION
I did some updates to work with `elm` 0.18 and added one function.

- Changed module declaration syntax
- Removed `map[2-5]` function since they are in the `elm-core` since version 3
- Run elm-format
- Added `values` function